### PR TITLE
Check for complete ruby_install_path before installing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@ class rubybuild(
 
     exec { "rubybuild install-ruby":
       command => "${ruby_build} ${ruby_version} ${$ruby_install_path}",
-      creates => "${ruby_install_dir}/${ruby_version}",
+      creates => "${ruby_install_path}",
       timeout => 0,
       require => Exec["rubybuild install"],
     }


### PR DESCRIPTION
Hi benben, I made a little patch that aims for avoiding the ruby install step in case I set the install_dir flag to false. Thanks!
